### PR TITLE
Resolve : Arithmetic on global 'enemy_health_scale' (a nil value)

### DIFF
--- a/abandonments.lua
+++ b/abandonments.lua
@@ -45,7 +45,7 @@ if (settings.startup["settings-warehouse-abandonments"].value) then
 
 -- Health Setting
 
-	
+	local enemy_health_scale = 1.0
 	if settings.startup["settings-enemy-health"].value == "easy" then
 	enemy_health_scale = 0.5
 	elseif settings.startup["settings-enemy-health"].value == "hard" then


### PR DESCRIPTION
Not sure if this was intended but after the upgrade to 2.1.18 the local declaration for `enemy_health_scale` was removed this caused my local to break. 

I've disabled all other mods.

the following is displayed in game 

```log
Failed to load mods: __factorioplus__/abandonments.lua:668: attempt to perform arithmetic on global 'enemy_health_scale' (a nil value)
stack traceback:
	__factorioplus__/abandonments.lua:668: in main chunk
	[C]: in function 'require'
	__factorioplus__/data.lua:28: in main chunk
```