### PR TITLE
Fixed crashsite pole red/green connections

### DIFF
--- a/crashsite.lua
+++ b/crashsite.lua
@@ -513,8 +513,8 @@ data:extend
         },
         wire =
         {
-          green = util.by_pixel(0, 0),
-          red = util.by_pixel(0, 0),
+          green = util.by_pixel(-16, -44),
+          red = util.by_pixel(-27, -39),
           copper = util.by_pixel(-24, -50),
         }
       },
@@ -527,8 +527,8 @@ data:extend
         },
         wire =
         {
-          green = util.by_pixel(0, 0),
-          red = util.by_pixel(0, 0),
+          green = util.by_pixel(8, -47),
+          red = util.by_pixel(22, -50),
           copper = util.by_pixel(16, -40),
         }
       },
@@ -541,8 +541,8 @@ data:extend
         },
         wire =
         {
-          green = util.by_pixel(0, 0),
-          red = util.by_pixel(0, 0),
+          green = util.by_pixel(-10, -46),
+          red = util.by_pixel(2, -40),
           copper =util.by_pixel(-11, -38),
         }
       },
@@ -555,8 +555,8 @@ data:extend
         },
         wire =
         {
-          green = util.by_pixel(0, 0),
-          red = util.by_pixel(0, 0),
+          green = util.by_pixel(-6, -35),
+          red = util.by_pixel(6, -37),
           copper = util.by_pixel(6, -29),
         }
       },


### PR DESCRIPTION
Hey Fishy, it's Maoman from the mod portal. Figured if I was gonna be suggesting tweaks like this I may as well do it officially, right? 

I noticed the red and green connection points on the crash site power poles weren't set, so they just connected at the base of the pole. I figured out how the pixel coords work and worked out the correct pixel points. They might be off by one or two pixels here or there because I had to divide by half, the way I was working, so I lost a tiny bit of fidelity. But they're a hell of a lot closer than "the ground" lol.

I'll be honest, I've been making a *lot* of tweaks to your mod over the past few days, but most of them are personal preference stuff, nothing I would try to enforce on other players. However there are a few changes I've made that I think could be integrated, such as this simple fix with no real downside. I'll make separate pull requests for each change so you can approve or deny them individually, and I'll try to be nice and descriptive so you don't have to work too hard ;) Sometimes I'll explain the "why" behind my change too, if I think it needs additional justification.

Thank you for all your work on this fantastic mod, and I hope we collaborate well. 